### PR TITLE
Run line-by-line and handle a nil object exception

### DIFF
--- a/1password2pass.rb
+++ b/1password2pass.rb
@@ -107,12 +107,22 @@ elsif File.extname(filename) =~ /.1pif/i
     pass = {}
     pass[:name] = "#{(options.group + "/") if options.group}#{entry[options.name]}"
     pass[:title] = entry[:title]
-    pass[:password] = entry[:secureContents][:fields].detect do |field|
-      field[:name] == "password" or field[:designation] == "password"
-    end[:value]
-    pass[:login] = entry[:secureContents][:fields].detect do |field|
-      field[:name] == "username" or field[:designation] == "username"
-    end[:value]
+    begin
+      pass[:password] = entry[:secureContents][:fields].detect do |field|
+        field[:name] == "password" or field[:designation] == "password"
+      end[:value]
+    rescue
+      puts "WARNING: No password found in entry " + entry[:title]
+      pass[:password] = {}
+    end
+    begin
+      pass[:login] = entry[:secureContents][:fields].detect do |field|
+        field[:name] == "username" or field[:designation] == "username"
+      end[:value]
+    rescue
+      puts "WARNING: No username found in entry " + entry[:title]
+      pass[:login] = {}
+    end
     pass[:url] = entry[:location]
     pass[:notes] = entry[:secureContents][:notesPlain]
     passwords << pass

--- a/1password2pass.rb
+++ b/1password2pass.rb
@@ -96,19 +96,13 @@ if File.extname(filename) =~ /.txt/i
 elsif File.extname(filename) =~ /.1pif/i
   require "json"
 
-  pif = File.open(filename).read
-  # Normalize line endings, explicitly preserving encoding just to be sure
-  pif.encode!(pif.encoding, universal_newline: true)
-  # 1PIF is almost JSON, but not quite:
-  pif.gsub!(/^\*\*\*.*\*\*\*$/, ",")
-  pif.rstrip!
-  pif.slice!(-1) if pif[-1] == ","
-  pif = JSON.parse("[#{pif}]", {symbolize_names: true})
+  File.readlines(filename).each do |line|
+    next if line =~ /^\*\*\*/
+    entry = JSON.parse(line, {symbolize_names: true})
 
-  options.name = :location if options.name == :url
+    options.name = :location if options.name == :url
 
-  # Import 1PIF
-  pif.each do |entry|
+    # Import 1PIF
     next unless entry[:typeName] == "webforms.WebForm"
     pass = {}
     pass[:name] = "#{(options.group + "/") if options.group}#{entry[options.name]}"


### PR DESCRIPTION
The first commit changes the way the program processes the 1pif file to go line by line instead of pulling it all in at once.  It means:
- the UUID lines between JSON objects can be easily ignored, and if they are not present the file still processes
- the process requires less memory
- it was easier to debug
- if a JSON object takes more than one line, this script will break.  (did not happen with my input file of about 1000 records.)

The second commit adds the exception begin/rescue/end handing to add an empty object when no password or username fields are found.
